### PR TITLE
Do not use abbreviations in 5. because of 6.

### DIFF
--- a/C# Coding Standards and Naming Conventions.md
+++ b/C# Coding Standards and Naming Conventions.md
@@ -74,9 +74,9 @@ public const string SHIPPINGTYPE = "DropShip";
 #### 5. Use meaningful names for variables. The following example uses seattleCustomers for customers who are located in Seattle:
 
 ```csharp
-var seattleCustomers = from cust in customers
-  where cust.City == "Seattle" 
-  select cust.Name;
+var seattleCustomers = from customer in customers
+  where customer.City == "Seattle" 
+  select customer.Name;
 ```
 
 ***Why: consistent with the Microsoft's .NET Framework and easy to read.***


### PR DESCRIPTION
The rule right after it says not to do it, yet it does it. Hypocritical, lol...