### PR TITLE
fixed typo: "Offical" --> "Official"

### DIFF
--- a/JavaScript Name and Coding Conventions.md
+++ b/JavaScript Name and Coding Conventions.md
@@ -193,7 +193,7 @@ var obj = getElementById("demo")
 2. CSS files should have a .css extension;
 3. JavaScript files should have a .js extension.
 
-## Offical Reference
+## Official Reference
 
 1. [Google JavaScript Style Guide](https://google.github.io/styleguide/jsguide.html#introduction)
 2. [JavaScript Style Guide and Coding Conventions](http://www.w3schools.com/js/js_conventions.asp) 


### PR DESCRIPTION
Fixes typo from "Offical" to "Official" in [JavaScript Name and Coding Conventions.md](https://github.com/ktaranov/naming-convention/blob/86883747bffd778414896bc56ba85b0ae967465d/JavaScript%20Name%20and%20Coding%20Conventions.md):

https://github.com/ktaranov/naming-convention/blob/86883747bffd778414896bc56ba85b0ae967465d/JavaScript%20Name%20and%20Coding%20Conventions.md?plain=1#L196
